### PR TITLE
Allowed resuming downloads

### DIFF
--- a/ogb/utils/url.py
+++ b/ogb/utils/url.py
@@ -1,15 +1,13 @@
-import urllib.request as ur
 import zipfile
 import os
 import os.path as osp
-from six.moves import urllib
 import errno
+import requests
 
 def decide_download(url):
-    d = ur.urlopen(url)
+    size_byte = int(requests.get(url).headers["content-length"])
     GBFACTOR = float(1 << 30)
-    size = int(d.info()["Content-Length"])/GBFACTOR
-    
+    size = size_byte/GBFACTOR
     ### confirm if larger than 1GB
     if size > 1:
         return input("This will download %.2fGB. Will you proceed? (y/N)\n" % (size)).lower() == "y"
@@ -34,6 +32,7 @@ def download_url(url, folder, log=True):
 
     filename = url.rpartition('/')[2]
     path = osp.join(folder, filename)
+    tmp_download_path = osp.join(folder, "_" + filename)
 
     if osp.exists(path):  # pragma: no cover
         if log:
@@ -44,11 +43,24 @@ def download_url(url, folder, log=True):
         print('Downloading', url)
 
     makedirs(folder)
-    data = urllib.request.urlopen(url)
 
-    with open(path, 'wb') as f:
-        f.write(data.read())
+    if osp.exists(tmp_download_path):
+        resume_header = {'Range': 'bytes=%d-' % osp.getsize(tmp_download_path)}
+        mode = "ab"
+    else:
+        resume_header = {}
+        mode = "wb"
 
+    with requests.get(url,
+                      headers=resume_header,
+                      stream=True,
+                      verify=False,
+                      allow_redirects=True) as r:
+        with open(tmp_download_path, mode) as f:
+            for chunk in r.iter_content(chunk_size=512 * 1024):
+                if chunk:
+                    f.write(chunk)
+    os.rename(tmp_download_path, path)
     return path
 
 def maybe_log(path, log=True):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='ogb',
         'scikit-learn>=0.20.0',
         'pandas>=0.24.0',
         'six>=1.12.0',
-        'urllib3>=1.24.0'
+        'requests>=2.18.0'
       ],
       license='MIT',
       packages=find_packages(exclude=['dataset', 'examples', 'docs']),


### PR DESCRIPTION
At the moment, aborted downloads will cause an error every time the dataset is loaded until the (empty) .zip file is manually deleted.

Changes included:
1. Downloaded chunks are written to a temporary .zip file (for example `_tox21.zip`) immediately. Once fully downloaded, it will then be moved to the original .zip file location (for example `tox21.zip`).
2. Download is resumed if the temporary zip file is found; if a file exists at the original location, this will be unzipped instead.
3. This uses `requests`; updating the `decide_download` code with `requests` allows dropping the `six` requirement (and the explicit installation of urllib3).

Note: If these changes are too much, a far simpler fix (which does not resume downloads but just ignores the empty zip file) can be found in [another branch](https://github.com/fdiehl/ogb/tree/fix_aborted_download).