### PR TITLE
Fix issue in GraphPropPredDataset.__getitem__

### DIFF
--- a/ogb/graphproppred/dataset.py
+++ b/ogb/graphproppred/dataset.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import shutil, os
+import numpy as np
 import os.path as osp
 from ogb.utils.url import decide_download, download_url, extract_zip
 from ogb.io.read_graph_raw import read_csv_graph_raw
@@ -80,7 +81,7 @@ class GraphPropPredDataset(object):
     def __getitem__(self, idx):
         """Get datapoint with index"""
 
-        if isinstance(idx, int):
+        if isinstance(idx, (int, np.integer)):
             return self.graphs[idx], self.labels[idx]
 
         raise IndexError(


### PR DESCRIPTION
Hi, 

this PR fixes an issue with the library-agnostic loader for graph property prediction. 
Because the indices provided by `dataset.get_idx_split()` are of type `np.int64` and the `__getitem__` method of `GraphPropPredDataset` checks only for `isinstance(idx, int)`, the following code causes a crash:

```python
from ogb.graphproppred import GraphPropPredDataset
dataset = GraphPropPredDataset(name = 'ogbg-mol-hiv')
splitted_idx = dataset.get_idx_split()
train_idx, valid_idx, test_idx = splitted_idx["train"], splitted_idx["valid"], splitted_idx["test"]
dataset[train_idx[0]]  # crashes
dataset[0]  # works as expected
```

The error on Python 3.7 is: 

```python
~/dev/tf2/lib/python3.7/site-packages/ogb/graphproppred/dataset.py in __getitem__(self, idx)
     83 
     84         raise IndexError(
---> 85             'Only integer is valid index (got {}).'.format(type(idx).__name__))
     86 
     87     def __len__(self):

IndexError: Only integer is valid index (got int64).
```

I have changed the code to check for `isinstance(idx, (int, np.integer))` instead.

Cheers and congrats for this project,
Daniele