### PR TITLE
Version check

### DIFF
--- a/ogb/version.py
+++ b/ogb/version.py
@@ -1,1 +1,24 @@
-__version__='1.2.1'
+import os
+import logging
+from threading import Thread
+
+os.environ['OUTDATED_IGNORE'] = '1'
+from outdated import check_outdated  # noqa
+
+
+__version__ = '1.2.1'
+
+
+def check():
+    try:
+        is_outdated, latest = check_outdated('ogb', __version__)
+        if is_outdated:
+            logging.warning(
+                f'The OGB package is out of date. Your version is '
+                f'{__version__}, while the latest version is {latest}.')
+    except Exception:
+        pass
+
+
+thread = Thread(target=check)
+thread.start()

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(name='ogb',
         'scikit-learn>=0.20.0',
         'pandas>=0.24.0',
         'six>=1.12.0',
-        'urllib3>=1.24.0'
+        'urllib3>=1.24.0',
+        'outdated>=0.2.0'
       ],
       license='MIT',
       packages=find_packages(exclude=['dataset', 'examples', 'docs']),


### PR DESCRIPTION
This PR implements a version check to warn the user in case it uses an older version of the OGB package. For this, it makes use of the `outdated` package. The whole procedure runs in a background thread (so it doesn't delay anything), and it will not fail in case someone is working offline.