### PR TITLE
Add pre_transform to InMemoryDataset's init (pyg)

### DIFF
--- a/ogb/linkproppred/dataset_pyg.py
+++ b/ogb/linkproppred/dataset_pyg.py
@@ -61,7 +61,7 @@ class PygLinkPropPredDataset(InMemoryDataset):
         self.is_hetero = self.meta_info['is hetero'] == 'True'
         self.binary = self.meta_info['binary'] == 'True'
 
-        super(PygLinkPropPredDataset, self).__init__(self.root, transform)
+        super(PygLinkPropPredDataset, self).__init__(self.root, transform, pre_transform)
         self.data, self.slices = torch.load(self.processed_paths[0])
 
     def get_edge_split(self, split_type = None):

--- a/ogb/nodeproppred/dataset_pyg.py
+++ b/ogb/nodeproppred/dataset_pyg.py
@@ -65,7 +65,7 @@ class PygNodePropPredDataset(InMemoryDataset):
         self.is_hetero = self.meta_info['is hetero'] == 'True'
         self.binary = self.meta_info['binary'] == 'True'
 
-        super(PygNodePropPredDataset, self).__init__(self.root, transform)
+        super(PygNodePropPredDataset, self).__init__(self.root, transform, pre_transform)
         self.data, self.slices = torch.load(self.processed_paths[0])
 
     def get_idx_split(self, split_type = None):


### PR DESCRIPTION
Looks like we have not passed `pre_transform` to pyg's `InMemoryDataset.__init__`.
I just added it to the `PygLinkPropPredDataset` and `PygNodePropPredDataset`.