### PR TITLE
change gnn type when virtual node is added

### DIFF
--- a/examples/lsc/pcqm4m/conv.py
+++ b/examples/lsc/pcqm4m/conv.py
@@ -171,9 +171,9 @@ class GNN_node_Virtualnode(torch.nn.Module):
         self.mlp_virtualnode_list = torch.nn.ModuleList()
 
         for layer in range(num_layers):
-            if gnn_type == 'gin':
+            if gnn_type == 'gin-virtual':
                 self.convs.append(GINConv(emb_dim))
-            elif gnn_type == 'gcn':
+            elif gnn_type == 'gcn-virtual':
                 self.convs.append(GCNConv(emb_dim))
             else:
                 ValueError('Undefined GNN type called {}'.format(gnn_type))


### PR DESCRIPTION
`gnn_type` is passed through and it works by only defining gic and virtual node as `True` but when loading a model `convs` would be empty