### PR TITLE
Includes better error handling when import smiles2graph

### DIFF
--- a/ogb/utils/__init__.py
+++ b/ogb/utils/__init__.py
@@ -1,4 +1,5 @@
 try:
-    from .mol import smiles2graph
-except ImportError:
-    pass
+    from ogb.mol import smiles2graph
+except Exception as e:
+    print("Error on imports, verify if all dependencies are installed correctly.")
+    raise e


### PR DESCRIPTION
While I was trying set up the dataset for the competition and ran into some issues importing the pcqm4m because my local instalation of the rdkit library didn't worked and I couldn't identify this because the error were being omitted. Well I put a explicit handling for this case.