### PR TITLE
Add padding_index to AtomEncoder and BondEncoder

### DIFF
--- a/ogb/graphproppred/mol_encoder.py
+++ b/ogb/graphproppred/mol_encoder.py
@@ -6,13 +6,13 @@ full_bond_feature_dims = get_bond_feature_dims()
 
 class AtomEncoder(torch.nn.Module):
 
-    def __init__(self, emb_dim):
+    def __init__(self, emb_dim, padding_idx=None):
         super(AtomEncoder, self).__init__()
         
         self.atom_embedding_list = torch.nn.ModuleList()
 
         for i, dim in enumerate(full_atom_feature_dims):
-            emb = torch.nn.Embedding(dim, emb_dim)
+            emb = torch.nn.Embedding(dim, emb_dim, padding_idx=padding_idx)
             torch.nn.init.xavier_uniform_(emb.weight.data)
             self.atom_embedding_list.append(emb)
 
@@ -26,13 +26,13 @@ class AtomEncoder(torch.nn.Module):
 
 class BondEncoder(torch.nn.Module):
     
-    def __init__(self, emb_dim):
+    def __init__(self, emb_dim, padding_idx=None):
         super(BondEncoder, self).__init__()
         
         self.bond_embedding_list = torch.nn.ModuleList()
 
         for i, dim in enumerate(full_bond_feature_dims):
-            emb = torch.nn.Embedding(dim, emb_dim)
+            emb = torch.nn.Embedding(dim, emb_dim, padding_idx=padding_idx)
             torch.nn.init.xavier_uniform_(emb.weight.data)
             self.bond_embedding_list.append(emb)
 


### PR DESCRIPTION
Add padding_index to AtomEncoder and BondEncoder in mol_encoder.py to support, e.g., virtual edges with zero-padding as features