### PR TITLE
Add padding option to AtomEncoder and BondEncoder

### DIFF
--- a/ogb/graphproppred/mol_encoder.py
+++ b/ogb/graphproppred/mol_encoder.py
@@ -6,13 +6,13 @@ full_bond_feature_dims = get_bond_feature_dims()
 
 class AtomEncoder(torch.nn.Module):
 
-    def __init__(self, emb_dim):
+    def __init__(self, emb_dim, padding_idx=None):
         super(AtomEncoder, self).__init__()
         
         self.atom_embedding_list = torch.nn.ModuleList()
 
         for i, dim in enumerate(full_atom_feature_dims):
-            emb = torch.nn.Embedding(dim, emb_dim)
+            emb = torch.nn.Embedding(dim, emb_dim, padding_idx=padding_idx)
             torch.nn.init.xavier_uniform_(emb.weight.data)
             self.atom_embedding_list.append(emb)
 
@@ -26,13 +26,13 @@ class AtomEncoder(torch.nn.Module):
 
 class BondEncoder(torch.nn.Module):
     
-    def __init__(self, emb_dim):
+    def __init__(self, emb_dim, padding_idx=None):
         super(BondEncoder, self).__init__()
         
         self.bond_embedding_list = torch.nn.ModuleList()
 
         for i, dim in enumerate(full_bond_feature_dims):
-            emb = torch.nn.Embedding(dim, emb_dim)
+            emb = torch.nn.Embedding(dim, emb_dim, padding_idx=padding_idx)
             torch.nn.init.xavier_uniform_(emb.weight.data)
             self.bond_embedding_list.append(emb)
 

--- a/ogb/graphproppred/mol_encoder.py
+++ b/ogb/graphproppred/mol_encoder.py
@@ -6,40 +6,61 @@ full_bond_feature_dims = get_bond_feature_dims()
 
 class AtomEncoder(torch.nn.Module):
 
-    def __init__(self, emb_dim, padding_idx=None):
+    def __init__(self, emb_dim, padding=False):
+        """
+        :param emb_dim: the dimension that the returned embedding will have
+        :param padding: set to true to map -1 to padding
+        """
         super(AtomEncoder, self).__init__()
         
         self.atom_embedding_list = torch.nn.ModuleList()
+        self.padding = padding
 
         for i, dim in enumerate(full_atom_feature_dims):
-            emb = torch.nn.Embedding(dim, emb_dim, padding_idx=padding_idx)
+            if self.padding:
+                emb = torch.nn.Embedding(dim + 1, emb_dim, padding_idx=0)
+            else:
+                emb = torch.nn.Embedding(dim, emb_dim)
             torch.nn.init.xavier_uniform_(emb.weight.data)
             self.atom_embedding_list.append(emb)
 
     def forward(self, x):
         x_embedding = 0
         for i in range(x.shape[1]):
-            x_embedding += self.atom_embedding_list[i](x[:,i])
+            if self.padding:
+                x_embedding += self.atom_embedding_list[i](x[:, i] + 1)
+            else:
+                x_embedding += self.atom_embedding_list[i](x[:, i])
 
         return x_embedding
 
 
 class BondEncoder(torch.nn.Module):
     
-    def __init__(self, emb_dim, padding_idx=None):
+    def __init__(self, emb_dim, padding=False):
+        """
+        :param emb_dim: the dimension that the returned embedding will have
+        :param padding: set to true to map -1 to padding
+        """
         super(BondEncoder, self).__init__()
         
         self.bond_embedding_list = torch.nn.ModuleList()
 
         for i, dim in enumerate(full_bond_feature_dims):
-            emb = torch.nn.Embedding(dim, emb_dim, padding_idx=padding_idx)
+            if padding:
+                emb = torch.nn.Embedding(dim + 1, emb_dim, padding_idx=0)
+            else:
+                emb = torch.nn.Embedding(dim, emb_dim)
             torch.nn.init.xavier_uniform_(emb.weight.data)
             self.bond_embedding_list.append(emb)
 
     def forward(self, edge_attr):
         bond_embedding = 0
         for i in range(edge_attr.shape[1]):
-            bond_embedding += self.bond_embedding_list[i](edge_attr[:,i])
+            if self.padding:
+                bond_embedding += self.bond_embedding_list[i](edge_attr[:, i] + 1)
+            else:
+                bond_embedding += self.bond_embedding_list[i](edge_attr[:, i])
 
         return bond_embedding   
 


### PR DESCRIPTION
Add padding option to AtomEncoder and BondEncoder in mol_encoder.py to support, e.g., virtual edges with zero-padding as features

