### PR TITLE
fix bug in proteins example

### DIFF
--- a/examples/nodeproppred/proteins/gnn.py
+++ b/examples/nodeproppred/proteins/gnn.py
@@ -5,6 +5,8 @@ import torch.nn.functional as F
 
 import torch_geometric.transforms as T
 from torch_geometric.nn import GCNConv, SAGEConv
+from torch_scatter import scatter
+from torch_sparse import SparseTensor
 
 from ogb.nodeproppred import PygNodePropPredDataset, Evaluator
 
@@ -119,13 +121,14 @@ def main():
     device = f'cuda:{args.device}' if torch.cuda.is_available() else 'cpu'
     device = torch.device(device)
 
-    dataset = PygNodePropPredDataset(name='ogbn-proteins',
-                                     transform=T.ToSparseTensor())
+    dataset = PygNodePropPredDataset(name='ogbn-proteins')
     data = dataset[0]
 
     # Move edge features to node features.
-    data.x = data.adj_t.mean(dim=1)
-    data.adj_t.set_value_(None)
+    data.x = scatter(data.edge_attr, data.edge_index[0], dim=0,
+                dim_size=data.num_nodes, reduce='mean').to('cpu')
+    data.adj_t = SparseTensor(row=data.edge_index[0], col=data.edge_index[1], 
+                value=torch.ones(data.edge_index[0].size(0)))
 
     split_idx = dataset.get_idx_split()
     train_idx = split_idx['train'].to(device)


### PR DESCRIPTION
Hi there, I'm using ogb and just got an error when I run the example GNN code for ogbn-proteins(ogb/examples/nodeproppred/proteins/gnn.py):

`File "/Users/qiantao/Mywork/Project/oneID mining/ogb-test/ogb/examples/nodeproppred/proteins/gnn.py", line 74, in train
    out = model(data.x, data.adj_t)[train_idx]`
  `File "/opt/miniconda3/envs/autogl/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1051, in _call_impl
    return forward_call(*input, **kwargs)`
  `File "/Users/qiantao/Mywork/Project/oneID mining/ogb-test/ogb/examples/nodeproppred/proteins/gnn.py", line 36, in forward
    x = conv(x, adj_t)`
 ` ...`
  `File "/opt/miniconda3/envs/autogl/lib/python3.9/site-packages/torch/nn/functional.py", line 1847, in linear
    return torch._C._nn.linear(input, weight, bias)`
`RuntimeError: mat1 and mat2 shapes cannot be multiplied (1x132534 and 1x256)`

It seems `data.adj_t` only contains adjacency information (`data.adj_t.to_dense()=[132534, 132534]`) and the code fails to aggregate the edge attributes to the nodes.
Referring to MLP.py in the same directory, I modify the code to load the dataset without sparse transformer `dataset = PygNodePropPredDataset(name='ogbn-proteins')` and generate `data.x` and `data.adj_t` based on `torch_scatter.scatter` and `torch_sparse.SparseTensor`.

Hope this helps!
