### PR TITLE
clone the data object to avoid modify original one

### DIFF
--- a/examples/nodeproppred/products/graph_saint.py
+++ b/examples/nodeproppred/products/graph_saint.py
@@ -105,6 +105,7 @@ def test(model, data, evaluator, subgraph_loader, device):
 
 
 def to_inductive(data):
+    data = data.clone()
     mask = data.train_mask
     data.x = data.x[mask]
     data.y = data.y[mask]


### PR DESCRIPTION
The example script has a bug when enabling "inductive" flag. This is the fix