### PR TITLE
Pandas 2.0.0 Compatibility with read_csv

### DIFF
--- a/ogb/graphproppred/dataset.py
+++ b/ogb/graphproppred/dataset.py
@@ -23,7 +23,7 @@ class GraphPropPredDataset(object):
             self.original_root = root
             self.root = osp.join(root, self.dir_name)
             
-            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col = 0)
+            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col=0, keep_default_na=False)
             if not self.name in master:
                 error_mssg = 'Invalid dataset name {}.\n'.format(self.name)
                 error_mssg += 'Available datasets are as follows:\n'

--- a/ogb/graphproppred/dataset_dgl.py
+++ b/ogb/graphproppred/dataset_dgl.py
@@ -32,7 +32,7 @@ class DglGraphPropPredDataset(object):
             self.original_root = root
             self.root = osp.join(root, self.dir_name)
             
-            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col = 0)
+            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col=0, keep_default_na=False)
             if not self.name in master:
                 error_mssg = 'Invalid dataset name {}.\n'.format(self.name)
                 error_mssg += 'Available datasets are as follows:\n'

--- a/ogb/graphproppred/dataset_pyg.py
+++ b/ogb/graphproppred/dataset_pyg.py
@@ -32,7 +32,7 @@ class PygGraphPropPredDataset(InMemoryDataset):
             self.original_root = root
             self.root = osp.join(root, self.dir_name)
             
-            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col = 0)
+            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col=0, keep_default_na=False)
             if not self.name in master:
                 error_mssg = 'Invalid dataset name {}.\n'.format(self.name)
                 error_mssg += 'Available datasets are as follows:\n'

--- a/ogb/graphproppred/evaluate.py
+++ b/ogb/graphproppred/evaluate.py
@@ -14,7 +14,7 @@ class Evaluator:
     def __init__(self, name):
         self.name = name
 
-        meta_info = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col = 0)
+        meta_info = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col=0, keep_default_na=False)
         if not self.name in meta_info:
             print(self.name)
             error_mssg = 'Invalid dataset name {}.\n'.format(self.name)

--- a/ogb/linkproppred/dataset.py
+++ b/ogb/linkproppred/dataset.py
@@ -23,7 +23,7 @@ class LinkPropPredDataset(object):
             self.original_root = root
             self.root = osp.join(root, self.dir_name)
             
-            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col = 0)
+            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col=0, keep_default_na=False)
             if not self.name in master:
                 error_mssg = 'Invalid dataset name {}.\n'.format(self.name)
                 error_mssg += 'Available datasets are as follows:\n'

--- a/ogb/linkproppred/dataset_dgl.py
+++ b/ogb/linkproppred/dataset_dgl.py
@@ -33,7 +33,7 @@ class DglLinkPropPredDataset(object):
             self.original_root = root
             self.root = osp.join(root, self.dir_name)
             
-            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col = 0)
+            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col=0, keep_default_na=False)
             if not self.name in master:
                 error_mssg = 'Invalid dataset name {}.\n'.format(self.name)
                 error_mssg += 'Available datasets are as follows:\n'

--- a/ogb/linkproppred/dataset_pyg.py
+++ b/ogb/linkproppred/dataset_pyg.py
@@ -31,7 +31,7 @@ class PygLinkPropPredDataset(InMemoryDataset):
             self.original_root = root
             self.root = osp.join(root, self.dir_name)
             
-            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col = 0)
+            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col=0, keep_default_na=False)
             if not self.name in master:
                 error_mssg = 'Invalid dataset name {}.\n'.format(self.name)
                 error_mssg += 'Available datasets are as follows:\n'

--- a/ogb/linkproppred/evaluate.py
+++ b/ogb/linkproppred/evaluate.py
@@ -14,7 +14,7 @@ class Evaluator:
     def __init__(self, name):
         self.name = name
 
-        meta_info = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col = 0)
+        meta_info = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col=0, keep_default_na=False)
         if not self.name in meta_info:
             print(self.name)
             error_mssg = 'Invalid dataset name {}.\n'.format(self.name)

--- a/ogb/linkproppred/make_master_file.py
+++ b/ogb/linkproppred/make_master_file.py
@@ -112,7 +112,7 @@ dataset_dict[name]['url'] = 'http://snap.stanford.edu/ogb/data/linkproppred/'+da
 ## For undirected grarph, we only store one directional information. This flag allows us to add inverse edge at pre-processing time
 dataset_dict[name]['add_inverse_edge'] = False 
 dataset_dict[name]['has_node_attr'] = True
-dataset_dict[name]['has_edge_attr'] = False
+dataset_dict[name]['has_edge_attr'] = True
 dataset_dict[name]['split'] = 'spatial'
 dataset_dict[name]['additional node files'] = 'None'
 dataset_dict[name]['additional edge files'] = 'None'

--- a/ogb/nodeproppred/dataset.py
+++ b/ogb/nodeproppred/dataset.py
@@ -26,7 +26,7 @@ class NodePropPredDataset(object):
             self.original_root = root
             self.root = osp.join(root, self.dir_name)
             
-            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col = 0)
+            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col=0, keep_default_na=False)
             if not self.name in master:
                 error_mssg = 'Invalid dataset name {}.\n'.format(self.name)
                 error_mssg += 'Available datasets are as follows:\n'

--- a/ogb/nodeproppred/dataset_dgl.py
+++ b/ogb/nodeproppred/dataset_dgl.py
@@ -32,7 +32,7 @@ class DglNodePropPredDataset(object):
             self.original_root = root
             self.root = osp.join(root, self.dir_name)
             
-            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col = 0)
+            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col=0, keep_default_na=False)
             if not self.name in master:
                 error_mssg = 'Invalid dataset name {}.\n'.format(self.name)
                 error_mssg += 'Available datasets are as follows:\n'

--- a/ogb/nodeproppred/dataset_pyg.py
+++ b/ogb/nodeproppred/dataset_pyg.py
@@ -32,7 +32,7 @@ class PygNodePropPredDataset(InMemoryDataset):
             self.original_root = root
             self.root = osp.join(root, self.dir_name)
             
-            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col = 0)
+            master = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col=0, keep_default_na=False)
             if not self.name in master:
                 error_mssg = 'Invalid dataset name {}.\n'.format(self.name)
                 error_mssg += 'Available datasets are as follows:\n'

--- a/ogb/nodeproppred/evaluate.py
+++ b/ogb/nodeproppred/evaluate.py
@@ -14,7 +14,7 @@ class Evaluator:
     def __init__(self, name):
         self.name = name
 
-        meta_info = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col = 0)
+        meta_info = pd.read_csv(os.path.join(os.path.dirname(__file__), 'master.csv'), index_col=0, keep_default_na=False)
         if not self.name in meta_info:
             print(self.name)
             error_mssg = 'Invalid dataset name {}.\n'.format(self.name)


### PR DESCRIPTION
Revision from previous closed [PR](https://github.com/snap-stanford/ogb/pull/419)

Pandas 2.0.0 was released [today](https://pandas.pydata.org/docs/dev/whatsnew/v2.0.0.html). A new argument called `dtype_backend` was added to the `read_csv()` function that appears to affect the default behavior when reading null values.

When the `master.csv` files are read with Pandas 2.0.0, the string value `"None" `now appears to be parsed by default to `NaN`. This is problematic in places where the `meta_info` dictionary's properties `additional edge files` and `additional node files` are checked to be `"None"`.

see lines [106](https://github.com/snap-stanford/ogb/blob/master/ogb/linkproppred/dataset.py#L106) and [111](https://github.com/snap-stanford/ogb/blob/master/ogb/linkproppred/dataset.py#L111) in ogb/linkpropped/dataset.py:

```python
if self.meta_info['additional node files'] == 'None':
    additional_node_files = []
else:
    additional_node_files = self.meta_info['additional node files'].split(',')
The .split(",") function called on these will throw AttributeError: 'float' object has no attribute 'split'.
```

The easiest way to fix this in the latest version that preserved compatibility with previous versions was to add `keep_default_na=False` when the csvs are read. 

Also very minor fix of inconsistency of the `has_edge_attr` property of the `ogbl-vessel` dataset, which was set to `False` in the `make_master_file.py` but is True in the latest [csv file committed here](https://github.com/snap-stanford/ogb/blob/master/ogb/linkproppred/master.csv). 