### PR TITLE
Updating `AtomEncoder` to improve input consistency

### DIFF
--- a/ogb/graphproppred/mol_encoder.py
+++ b/ogb/graphproppred/mol_encoder.py
@@ -5,12 +5,16 @@ full_atom_feature_dims = get_atom_feature_dims()
 full_bond_feature_dims = get_bond_feature_dims()
 
 class AtomEncoder(torch.nn.Module):
-    def __init__(self, emb_dim, num_atoms_list):
+    def __init__(self, emb_dim, num_atoms_feat=None):
         super(AtomEncoder, self).__init__()
+        
         self.atom_embedding_list = torch.nn.ModuleList()
 
-        for i, num_atoms in enumerate(num_atoms_list):
-            emb = torch.nn.Embedding(num_atoms, emb_dim)
+        if num_atoms_feat is not None:
+            full_atom_feature_dims = num_atoms_feat
+
+        for i, dim in enumerate(full_atom_feature_dims):
+            emb = torch.nn.Embedding(dim, emb_dim)
             torch.nn.init.xavier_uniform_(emb.weight.data)
             self.atom_embedding_list.append(emb)
 

--- a/ogb/graphproppred/mol_encoder.py
+++ b/ogb/graphproppred/mol_encoder.py
@@ -5,14 +5,12 @@ full_atom_feature_dims = get_atom_feature_dims()
 full_bond_feature_dims = get_bond_feature_dims()
 
 class AtomEncoder(torch.nn.Module):
-
-    def __init__(self, emb_dim):
+    def __init__(self, emb_dim, num_atoms_list):
         super(AtomEncoder, self).__init__()
-        
         self.atom_embedding_list = torch.nn.ModuleList()
 
-        for i, dim in enumerate(full_atom_feature_dims):
-            emb = torch.nn.Embedding(dim, emb_dim)
+        for i, num_atoms in enumerate(num_atoms_list):
+            emb = torch.nn.Embedding(num_atoms, emb_dim)
             torch.nn.init.xavier_uniform_(emb.weight.data)
             self.atom_embedding_list.append(emb)
 

--- a/ogb/graphproppred/mol_encoder.py
+++ b/ogb/graphproppred/mol_encoder.py
@@ -5,13 +5,13 @@ full_atom_feature_dims = get_atom_feature_dims()
 full_bond_feature_dims = get_bond_feature_dims()
 
 class AtomEncoder(torch.nn.Module):
-    def __init__(self, emb_dim, num_atoms_feat=None):
+    def __init__(self, emb_dim, optional_full_atom_features_dims=None):
         super(AtomEncoder, self).__init__()
-        
+
         self.atom_embedding_list = torch.nn.ModuleList()
 
-        if num_atoms_feat is not None:
-            full_atom_feature_dims = num_atoms_feat
+        if optional_full_atom_features_dims is not None:
+            full_atom_feature_dims = optional_full_atom_features_dims
 
         for i, dim in enumerate(full_atom_feature_dims):
             emb = torch.nn.Embedding(dim, emb_dim)


### PR DESCRIPTION
This pull request updates the `AtomEncoder` class to improve input consistency when working with complex input data.

In the original code, the `full_atom_feature_dims` list was used to determine the number of atoms for each element in the input `x` tensor. However, this may not be consistent with the actual number of atoms in the input tensor, which can lead to errors related to mismatched tensor shapes or indexing operations.

To address this issue, I updated the `AtomEncoder` class to take an additional argument `num_atoms_list`, which specifies the number of atoms for each element in the input tensor. This ensures that the correct number of atoms is used for each element, regardless of the complexity of the input data.