### PR TITLE
another minor fix

### DIFF
--- a/examples/lsc/mag240m/gnn.py
+++ b/examples/lsc/mag240m/gnn.py
@@ -84,7 +84,8 @@ class MAG240M(LightningDataModule):
         self.train_idx.share_memory_()
         self.val_idx = torch.from_numpy(dataset.get_idx_split('valid'))
         self.val_idx.share_memory_()
-        self.test_idx = torch.from_numpy(dataset.get_idx_split('test-dev'))
+        test_key = 'test-dev' if WITHOUT_LIGHTNING_V2 else 'test'
+        self.test_idx = torch.from_numpy(dataset.get_idx_split(test_key))
         self.test_idx.share_memory_()
 
         if self.in_memory:

--- a/examples/lsc/mag240m/rgnn.py
+++ b/examples/lsc/mag240m/rgnn.py
@@ -228,7 +228,8 @@ class MAG240M(LightningDataModule):
         self.train_idx.share_memory_()
         self.val_idx = torch.from_numpy(dataset.get_idx_split('valid'))
         self.val_idx.share_memory_()
-        self.test_idx = torch.from_numpy(dataset.get_idx_split('test-dev'))
+        test_key = 'test-dev' if WITHOUT_LIGHTNING_V2 else 'test'
+        self.test_idx = torch.from_numpy(dataset.get_idx_split(test_key))
         self.test_idx.share_memory_()
 
         N = dataset.num_papers + dataset.num_authors + dataset.num_institutions


### PR DESCRIPTION
w/o fix:  
```
File "/usr/local/lib/python3.8/dist-packages/pytorch_lightning/trainer/call.py", line 162, in _call_lightning_datamodule_hook
    return fn(*args, **kwargs)
  File "gnn.py", line 86, in setup
    self.test_idx = torch.from_numpy(dataset.get_idx_split('test-dev'))
  File "/usr/local/lib/python3.8/dist-packages/ogb/lsc/mag240m.py", line 75, in get_idx_split
    return self.__split__ if split is None else self.__split__[split]
KeyError: 'test-dev'
```

->
w/:
```
Namespace(batch_size=1024, device='0', dropout=0.5, epochs=100, evaluate=False, hidden_channels=1024, in_memory=False, model='graphsage', sizes=[25, 15])
Global seed set to 42
#Params 4884633
GPU available: True (cuda), used: True
TPU available: False, using: 0 TPU cores
IPU available: False, using: 0 IPUs
HPU available: False, using: 0 HPUs
Missing logger folder: logs/graphsage/lightning_logs
Reading dataset... 
Done! [622.25s]
LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0,1,2,3,4,5,6,7]

  | Name      | Type       | Params
-----------------------------------------
0 | convs     | ModuleList | 3.7 M 
1 | norms     | ModuleList | 4.1 K 
2 | skips     | ModuleList | 0     
3 | mlp       | Sequential | 1.2 M 
4 | train_acc | Accuracy   | 0     
5 | val_acc   | Accuracy   | 0     
6 | test_acc  | Accuracy   | 0     
-----------------------------------------
4.9 M     Trainable params
0         Non-trainable params
4.9 M     Total params
19.539    Total estimated model params size (MB)
Sanity Checking: 0it [00:00, ?it/s]
```