### PR TITLE
remove dropout adj, use dropout edge

### DIFF
--- a/examples/nodeproppred/papers100M/node2vec.py
+++ b/examples/nodeproppred/papers100M/node2vec.py
@@ -2,7 +2,7 @@ import argparse
 
 import torch
 from torch_geometric.nn import Node2Vec
-from torch_geometric.utils import to_undirected, dropout_adj
+from torch_geometric.utils import to_undirected, dropout_edge
 from tqdm.auto import tqdm
 
 from ogb.nodeproppred import PygNodePropPredDataset
@@ -51,11 +51,9 @@ def main():
 
     data = dataset[0]
 
-    # if args.add_inverse:
-
     print('Making the graph undirected.')
     ### Randomly drop some edges to avoid segmentation fault
-    data.edge_index, _ = dropout_adj(data.edge_index, p = args.dropedge_rate, num_nodes= data.num_nodes)
+    data.edge_index, _ = dropout_edge(data.edge_index, p = args.dropedge_rate)
     data.edge_index = to_undirected(data.edge_index, data.num_nodes)
     filename = 'data_dict.pt'
 

--- a/examples/nodeproppred/papers100M/sgc.py
+++ b/examples/nodeproppred/papers100M/sgc.py
@@ -4,7 +4,7 @@ from tqdm.auto import tqdm
 import torch
 import torch.nn.functional as F
 from torch_sparse import SparseTensor
-from torch_geometric.utils import to_undirected, dropout_adj
+from torch_geometric.utils import to_undirected, dropout_edge
 
 from ogb.nodeproppred import PygNodePropPredDataset
 
@@ -26,7 +26,7 @@ def main():
 
     print('Making the graph undirected.')
     ### Randomly drop some edges to save computation
-    data.edge_index, _ = dropout_adj(data.edge_index, p = args.dropedge_rate, num_nodes= data.num_nodes)
+    data.edge_index, _ = dropout_edge(data.edge_index, p = args.dropedge_rate)
     data.edge_index = to_undirected(data.edge_index, data.num_nodes)
 
     print(data)


### PR DESCRIPTION
class:`~torch_geometric.utils.dropout_adj` is deprecated and will be removed in a future release.
 Use :class:`torch_geometric.utils.dropout_edge` instead.