### PR TITLE
add reorder atom in mol.py

### DIFF
--- a/ogb/utils/mol.py
+++ b/ogb/utils/mol.py
@@ -4,12 +4,12 @@ from rdkit import Chem
 import numpy as np
 
 
-def CanonicalRankAtoms(mol):
+def ReorderCanonicalRankAtoms(mol):
     order = tuple(zip(*sorted([(j, i) for i, j in enumerate(Chem.CanonicalRankAtoms(mol))])))[1]
     mol_renum = Chem.RenumberAtoms(mol, order)
     return mol_renum, order
 
-def smiles2graph(smiles_string, removeHs=True):
+def smiles2graph(smiles_string, removeHs=True, reorder_atoms=False):
     """
     Converts SMILES string to graph Data object
     :input: SMILES string (str)
@@ -18,7 +18,8 @@ def smiles2graph(smiles_string, removeHs=True):
 
     mol = Chem.MolFromSmiles(smiles_string)
     mol = mol if removeHs else Chem.AddHs(mol)
-    mol, _ = ReorderAtoms(mol)
+    if reorder_atoms:
+        mol, _ = ReorderCanonicalRankAtoms(mol)
 
     # atoms
     atom_features_list = []

--- a/ogb/utils/mol.py
+++ b/ogb/utils/mol.py
@@ -3,6 +3,12 @@ from ogb.utils.features import (allowable_features, atom_to_feature_vector,
 from rdkit import Chem
 import numpy as np
 
+
+def ReorderAtoms(mol):
+    order = tuple(zip(*sorted([(j, i) for i, j in enumerate(Chem.CanonicalRankAtoms(mol))])))[1]
+    mol_renum = Chem.RenumberAtoms(mol, order)
+    return mol_renum
+
 def smiles2graph(smiles_string, removeHs=True):
     """
     Converts SMILES string to graph Data object
@@ -12,6 +18,7 @@ def smiles2graph(smiles_string, removeHs=True):
 
     mol = Chem.MolFromSmiles(smiles_string)
     mol = mol if removeHs else Chem.AddHs(mol)
+    mol = ReorderAtoms(mol)
 
     # atoms
     atom_features_list = []

--- a/ogb/utils/mol.py
+++ b/ogb/utils/mol.py
@@ -4,7 +4,7 @@ from rdkit import Chem
 import numpy as np
 
 
-def ReorderAtoms(mol):
+def CanonicalRankAtoms(mol):
     order = tuple(zip(*sorted([(j, i) for i, j in enumerate(Chem.CanonicalRankAtoms(mol))])))[1]
     mol_renum = Chem.RenumberAtoms(mol, order)
     return mol_renum, order

--- a/ogb/utils/mol.py
+++ b/ogb/utils/mol.py
@@ -7,7 +7,7 @@ import numpy as np
 def ReorderAtoms(mol):
     order = tuple(zip(*sorted([(j, i) for i, j in enumerate(Chem.CanonicalRankAtoms(mol))])))[1]
     mol_renum = Chem.RenumberAtoms(mol, order)
-    return mol_renum
+    return mol_renum, order
 
 def smiles2graph(smiles_string, removeHs=True):
     """
@@ -18,7 +18,7 @@ def smiles2graph(smiles_string, removeHs=True):
 
     mol = Chem.MolFromSmiles(smiles_string)
     mol = mol if removeHs else Chem.AddHs(mol)
-    mol = ReorderAtoms(mol)
+    mol, _ = ReorderAtoms(mol)
 
     # atoms
     atom_features_list = []


### PR DESCRIPTION
Add `reorder atom` function to achieve **atom-to-atom correspondence** in **PCQM4Mv2** when dealing with sdf.
The code is originally from [ViSNet](https://github.com/microsoft/ViSNet/blob/OGB-LSC%40NIPS2022/OGB_ViSNet/datasets/utils.py#L12).
We can test the order by
```
from rdkit import Chem
from ogb.utils import ReorderAtoms

suppl = Chem.SDMolSupplier('pcqm4m-v2-train.sdf')
mol = suppl[0]
mol = ReorderAtoms(mol)
atomic_number = []          
for atom in mol.GetAtoms():
    atomic_number.append(atom.GetAtomicNum())
print(atomic_number)
# >>> [6, 6, 6, 6, 8, 6, 6, 6, 6, 6, 8, 8, 6, 6, 6, 6, 7]
```

and 

```
from ogb.lsc import PCQM4Mv2Dataset
from ogb.utils import smiles2graph
from functools import partial

dataset = PCQM4Mv2Dataset(root = ROOT, smiles2graph=partial(smiles2graph, removeHs=True))
print(dataset[0].x[:, 0] + 1) # atomic number
# >>> [6, 6, 6, 6, 8, 6, 6, 6, 6, 6, 8, 8, 6, 6, 6, 6, 7]
```