### PR TITLE
Resolution for Import Error, Solve `import PygNodePropPredDataset` hang the program

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(name='ogb',
         'pandas>=0.24.0',
         'six>=1.12.0',
         'urllib3>=1.24.0',
-        'outdated>=0.2.0'
+        'outdated>=0.2.0',
+        'joblib>=1.3.2'
       ],
       license='MIT',
       packages=find_packages(exclude=['dataset', 'examples', 'docs']),


### PR DESCRIPTION
To address the issue described in [GitHub issue #461](https://github.com/snap-stanford/ogb/issues/461), it is identified that the problem lies in the following code snippet:

 `  File "/opt/conda/lib/python3.10/site-packages/joblib/backports.py", line 22, in <module>
    import distutils  # noqa`

In newer versions of joblib, the import of distutils is no longer necessary.

To resolve this, consider updating your code or the library to the latest version, as newer versions of joblib have eliminated the need for the explicit import of distutils. This should resolve the issue and prevent the mentioned error. 
