### PR TITLE
Enable torch.load in dataset_pyg.py

### DIFF
--- a/ogb/graphproppred/dataset_pyg.py
+++ b/ogb/graphproppred/dataset_pyg.py
@@ -65,7 +65,7 @@ class PygGraphPropPredDataset(InMemoryDataset):
 
         super(PygGraphPropPredDataset, self).__init__(self.root, transform, pre_transform)
 
-        self.data, self.slices = torch.load(self.processed_paths[0])
+        self.data, self.slices = torch.load(self.processed_paths[0], weights_only=False)
 
     def get_idx_split(self, split_type = None):
         if split_type is None:
@@ -75,7 +75,7 @@ class PygGraphPropPredDataset(InMemoryDataset):
 
         # short-cut if split_dict.pt exists
         if os.path.isfile(os.path.join(path, 'split_dict.pt')):
-            return torch.load(os.path.join(path, 'split_dict.pt'))
+            return torch.load(os.path.join(path, 'split_dict.pt'), weights_only=False)
 
         train_idx = pd.read_csv(osp.join(path, 'train.csv.gz'), compression='gzip', header = None).values.T[0]
         valid_idx = pd.read_csv(osp.join(path, 'valid.csv.gz'), compression='gzip', header = None).values.T[0]


### PR DESCRIPTION
It seems like Torch has recently changed its load function to default to "weights_only=True". This causes errors in the current version of this library.  I am not an expert, and I don't know if my solution is safe, but this was my workaround to get your code running.