### PR TITLE
fix for pytorch data load weigths_only

### DIFF
--- a/examples/linkproppred/biokg/run.py
+++ b/examples/linkproppred/biokg/run.py
@@ -224,7 +224,7 @@ def main(args):
     if args.init_checkpoint:
         # Restore model from checkpoint directory
         logging.info('Loading checkpoint %s...' % args.init_checkpoint)
-        checkpoint = torch.load(os.path.join(args.init_checkpoint, 'checkpoint'))
+        checkpoint = torch.load(os.path.join(args.init_checkpoint, 'checkpoint'), weights_only=False)
         entity_dict = checkpoint['entity_dict']
 
     if args.do_train:

--- a/examples/linkproppred/citation2/mlp.py
+++ b/examples/linkproppred/citation2/mlp.py
@@ -138,7 +138,7 @@ def main():
 
     x = data.x
     if args.use_node_embedding:
-        embedding = torch.load('embedding.pt', map_location='cpu')
+        embedding = torch.load('embedding.pt', map_location='cpu', weights_only=False)
         x = torch.cat([x, embedding], dim=-1)
     x = x.to(device)
 

--- a/examples/linkproppred/collab/mlp.py
+++ b/examples/linkproppred/collab/mlp.py
@@ -154,7 +154,7 @@ def main():
 
     x = data.x
     if args.use_node_embedding:
-        embedding = torch.load('embedding.pt', map_location='cpu')
+        embedding = torch.load('embedding.pt', map_location='cpu', weights_only=False)
         x = torch.cat([x, embedding], dim=-1)
     x = x.to(device)
 

--- a/examples/linkproppred/ddi/mlp.py
+++ b/examples/linkproppred/ddi/mlp.py
@@ -158,7 +158,7 @@ def main():
     idx = idx[:split_edge['valid']['edge'].size(0)]
     split_edge['eval_train'] = {'edge': split_edge['train']['edge'][idx]}
 
-    x = torch.load('embedding.pt', map_location='cpu').to(device)
+    x = torch.load('embedding.pt', map_location='cpu', weights_only=False).to(device)
 
     predictor = LinkPredictor(x.size(-1), args.hidden_channels, 1,
                               args.num_layers, args.dropout).to(device)

--- a/examples/linkproppred/ppa/gnn.py
+++ b/examples/linkproppred/ppa/gnn.py
@@ -223,7 +223,7 @@ def main():
     data = dataset[0]
     data.x = data.x.to(torch.float)
     if args.use_node_embedding:
-        data.x = torch.cat([data.x, torch.load('embedding.pt')], dim=-1)
+        data.x = torch.cat([data.x, torch.load('embedding.pt', weights_only=False)], dim=-1)
     data = data.to(device)
 
     split_edge = dataset.get_edge_split()

--- a/examples/linkproppred/ppa/mlp.py
+++ b/examples/linkproppred/ppa/mlp.py
@@ -152,7 +152,7 @@ def main():
     data = dataset[0]
 
     x = data.x.to(torch.float)
-    embedding = torch.load('embedding.pt', map_location='cpu')
+    embedding = torch.load('embedding.pt', map_location='cpu', weights_only=False)
     x = torch.cat([x, embedding], dim=-1)
     x = x.to(device)
 

--- a/examples/linkproppred/vessel/gnn.py
+++ b/examples/linkproppred/vessel/gnn.py
@@ -234,7 +234,7 @@ def main():
 
     data.x = data.x.to(torch.float)
     if args.use_node_embedding:
-        data.x = torch.cat([data.x, torch.load('embedding.pt')], dim=-1)
+        data.x = torch.cat([data.x, torch.load('embedding.pt', weights_only=False)], dim=-1)
     data = data.to(device)
 
     split_edge = dataset.get_edge_split()

--- a/examples/linkproppred/vessel/mlp.py
+++ b/examples/linkproppred/vessel/mlp.py
@@ -166,7 +166,7 @@ def main():
 
     # use embeddings
     x = data.x.to(torch.float)
-    embedding = torch.load('embedding.pt', map_location='cpu')
+    embedding = torch.load('embedding.pt', map_location='cpu', weights_only=False)
     x = torch.cat([x, embedding], dim=-1)
     x = x.to(device)
 

--- a/examples/linkproppred/wikikg2/run.py
+++ b/examples/linkproppred/wikikg2/run.py
@@ -251,7 +251,7 @@ def main(args):
     if args.init_checkpoint:
         # Restore model from checkpoint directory
         logging.info('Loading checkpoint %s...' % args.init_checkpoint)
-        checkpoint = torch.load(os.path.join(args.init_checkpoint, 'checkpoint'))
+        checkpoint = torch.load(os.path.join(args.init_checkpoint, 'checkpoint'), weights_only=False)
         init_step = checkpoint['step']
         kge_model.load_state_dict(checkpoint['model_state_dict'])
         if args.do_train:

--- a/examples/lsc/mag240m/correct_and_smooth.py
+++ b/examples/lsc/mag240m/correct_and_smooth.py
@@ -33,11 +33,11 @@ if __name__ == '__main__':
     print('Reading adjacency matrix...', end=' ', flush=True)
     path = f'{dataset.dir}/paper_to_paper_symmetric_gcn.pt'
     if osp.exists(path):
-        adj_t = torch.load(path)
+        adj_t = torch.load(path, weights_only=False)
     else:
         path_sym = f'{dataset.dir}/paper_to_paper_symmetric.pt'
         if osp.exists(path_sym):
-            adj_t = torch.load(path_sym)
+            adj_t = torch.load(path_sym, weights_only=False)
         else:
             edge_index = dataset.edge_index('paper', 'cites', 'paper')
             edge_index = torch.from_numpy(edge_index)

--- a/examples/lsc/mag240m/gnn.py
+++ b/examples/lsc/mag240m/gnn.py
@@ -94,7 +94,7 @@ class MAG240M(LightningDataModule):
         self.y = torch.from_numpy(dataset.all_paper_label)
 
         path = f'{dataset.dir}/paper_to_paper_symmetric.pt'
-        self.adj_t = torch.load(path)
+        self.adj_t = torch.load(path, weights_only=False)
         print(f'Done! [{time.perf_counter() - t:.2f}s]')
 
     def train_dataloader(self):

--- a/examples/lsc/mag240m/label_prop.py
+++ b/examples/lsc/mag240m/label_prop.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     print('Reading adjacency matrix...', end=' ', flush=True)
     path = f'{dataset.dir}/paper_to_paper_symmetric.pt'
     if osp.exists(path):
-        adj_t = torch.load(path)
+        adj_t = torch.load(path, weights_only=False)
     else:
         edge_index = dataset.edge_index('paper', 'cites', 'paper')
         edge_index = torch.from_numpy(edge_index)

--- a/examples/lsc/mag240m/preprocess_correct_and_smooth.py
+++ b/examples/lsc/mag240m/preprocess_correct_and_smooth.py
@@ -133,7 +133,7 @@ if __name__ == '__main__':
                   f'Train: {train_acc:.4f}, Valid: {valid_acc:.4f}, '
                   f'Best: {best_valid_acc:.4f}')
 
-    model.load_state_dict(torch.load('results/cs/model.pt'))
+    model.load_state_dict(torch.load('results/cs/model.pt', weights_only=False))
     model.eval()
 
     pbar = tqdm(total=dataset.num_papers)

--- a/examples/lsc/mag240m/preprocess_sgc.py
+++ b/examples/lsc/mag240m/preprocess_sgc.py
@@ -25,11 +25,11 @@ if __name__ == '__main__':
     print('Reading adjacency matrix...', end=' ', flush=True)
     path = f'{dataset.dir}/paper_to_paper_symmetric_gcn.pt'
     if osp.exists(path):
-        adj_t = torch.load(path)
+        adj_t = torch.load(path, weights_only=False)
     else:
         path_sym = f'{dataset.dir}/paper_to_paper_symmetric.pt'
         if osp.exists(path_sym):
-            adj_t = torch.load(path_sym)
+            adj_t = torch.load(path_sym, weights_only=False)
         else:
             edge_index = dataset.edge_index('paper', 'cites', 'paper')
             edge_index = torch.from_numpy(edge_index)

--- a/examples/lsc/mag240m/rgnn.py
+++ b/examples/lsc/mag240m/rgnn.py
@@ -101,7 +101,7 @@ class MAG240M(LightningDataModule):
             print('Merging adjacency matrices...', end=' ', flush=True)
 
             row, col, _ = torch.load(
-                f'{dataset.dir}/paper_to_paper_symmetric.pt').coo()
+                f'{dataset.dir}/paper_to_paper_symmetric.pt', weights_only=False).coo()
             rows, cols = [row], [col]
 
             edge_index = dataset.edge_index('author', 'writes', 'paper')
@@ -246,7 +246,7 @@ class MAG240M(LightningDataModule):
         self.y = torch.from_numpy(dataset.all_paper_label)
 
         path = f'{dataset.dir}/full_adj_t.pt'
-        self.adj_t = torch.load(path)
+        self.adj_t = torch.load(path, weights_only=False)
         print(f'Done! [{time.perf_counter() - t:.2f}s]')
 
     def train_dataloader(self):

--- a/examples/lsc/pcqm4m-v2/main_gnn_multi_gpu.py
+++ b/examples/lsc/pcqm4m-v2/main_gnn_multi_gpu.py
@@ -173,7 +173,7 @@ def run(rank, dataset, args):
 
     checkpoint_path = os.path.join(args.checkpoint_dir, 'checkpoint.pt')
     if os.path.isfile(checkpoint_path):
-        checkpoint = torch.load(checkpoint_path)
+        checkpoint = torch.load(checkpoint_path, weights_only=False)
 
         current_epoch = checkpoint['epoch'] + 1
         model.load_state_dict(checkpoint['model_state_dict'])

--- a/examples/lsc/pcqm4m-v2/main_mlpfp.py
+++ b/examples/lsc/pcqm4m-v2/main_mlpfp.py
@@ -155,7 +155,7 @@ def main_mlp():
     dataset = PCQM4Mv2Dataset(root='dataset/', only_smiles=True)
     fp_processed_file = preprocess_fp(dataset, args.radius)
 
-    data_dict = torch.load(fp_processed_file)
+    data_dict = torch.load(fp_processed_file, weights_only=False)
     X, Y = data_dict['X'], data_dict['Y']
         
     split_idx = dataset.get_idx_split()

--- a/examples/lsc/pcqm4m/main_mlpfp.py
+++ b/examples/lsc/pcqm4m/main_mlpfp.py
@@ -155,7 +155,7 @@ def main_mlp():
     dataset = PCQM4MDataset(root='dataset/', only_smiles=True)
     fp_processed_file = preprocess_fp(dataset, args.radius)
 
-    data_dict = torch.load(fp_processed_file)
+    data_dict = torch.load(fp_processed_file, weights_only=False)
     X, Y = data_dict['X'], data_dict['Y']
         
     split_idx = dataset.get_idx_split()

--- a/examples/lsc/wikikg90m/save_test_submission.py
+++ b/examples/lsc/wikikg90m/save_test_submission.py
@@ -30,8 +30,8 @@ if __name__ == '__main__':
         valid_result_dict = defaultdict(lambda: defaultdict(list))
         test_result_dict = defaultdict(lambda: defaultdict(list))
         for proc in range(num_proc):
-            valid_result_dict_proc = torch.load(os.path.join(path, "valid_{}_{}.pkl".format(proc, step)), map_location=device)
-            test_result_dict_proc = torch.load(os.path.join(path, "test_{}_{}.pkl".format(proc, step)), map_location=device)
+            valid_result_dict_proc = torch.load(os.path.join(path, "valid_{}_{}.pkl".format(proc, step)), map_location=device, weights_only=False)
+            test_result_dict_proc = torch.load(os.path.join(path, "test_{}_{}.pkl".format(proc, step)), map_location=device, weights_only=False)
             for result_dict_proc, result_dict in zip([valid_result_dict_proc, test_result_dict_proc], [valid_result_dict, test_result_dict]):
                 for key in result_dict_proc['h,r->t']:
                     result_dict['h,r->t'][key].append(result_dict_proc['h,r->t'][key].numpy())

--- a/examples/nodeproppred/arxiv/mlp.py
+++ b/examples/nodeproppred/arxiv/mlp.py
@@ -98,7 +98,7 @@ def main():
 
     x = data.x
     if args.use_node_embedding:
-        embedding = torch.load('embedding.pt', map_location='cpu')
+        embedding = torch.load('embedding.pt', map_location='cpu', weights_only=False)
         x = torch.cat([x, embedding], dim=-1)
     x = x.to(device)
 

--- a/examples/nodeproppred/mag/mlp.py
+++ b/examples/nodeproppred/mag/mlp.py
@@ -93,7 +93,7 @@ def main():
 
     x = data.x_dict['paper']
     if args.use_node_embedding:
-        embedding = torch.load('embedding.pt', map_location='cpu')
+        embedding = torch.load('embedding.pt', map_location='cpu', weights_only=False)
         x = torch.cat([x, embedding], dim=-1)
     x = x.to(device)
 

--- a/examples/nodeproppred/papers100M/mlp.py
+++ b/examples/nodeproppred/papers100M/mlp.py
@@ -112,7 +112,7 @@ def main():
 
     if not args.use_sgc_embedding:
         try:
-            data_dict = torch.load('data_dict.pt')
+            data_dict = torch.load('data_dict.pt', weights_only=False)
         except:
             raise RuntimeError('data_dict.pt not found. Need to run python node2vec.py first')
         x = data_dict['node_feat']
@@ -129,7 +129,7 @@ def main():
             raise ValueError('No option to use node embedding and sgc embedding at the same time.')
         else:
             try:
-                sgc_dict = torch.load('sgc_dict.pt')
+                sgc_dict = torch.load('sgc_dict.pt', weights_only=False)
             except:
                 raise RuntimeError('sgc_dict.pt not found. Need to run python sgc.py first')
 

--- a/examples/nodeproppred/products/mlp.py
+++ b/examples/nodeproppred/products/mlp.py
@@ -92,7 +92,7 @@ def main():
 
     x = data.x
     if args.use_node_embedding:
-        embedding = torch.load('embedding.pt', map_location='cpu')
+        embedding = torch.load('embedding.pt', map_location='cpu', weights_only=False)
         x = torch.cat([x, embedding], dim=-1)
     x = x.to(device)
 

--- a/examples/nodeproppred/proteins/mlp.py
+++ b/examples/nodeproppred/proteins/mlp.py
@@ -96,7 +96,7 @@ def main():
                 dim_size=data.num_nodes, reduce='mean').to('cpu')
 
     if args.use_node_embedding:
-        embedding = torch.load('embedding.pt', map_location='cpu')
+        embedding = torch.load('embedding.pt', map_location='cpu', weights_only=False)
         x = torch.cat([x, embedding], dim=-1)
 
     x = x.to(device)

--- a/ogb/graphproppred/dataset.py
+++ b/ogb/graphproppred/dataset.py
@@ -64,7 +64,7 @@ class GraphPropPredDataset(object):
         pre_processed_file_path = osp.join(processed_dir, 'data_processed')
 
         if os.path.exists(pre_processed_file_path):
-            loaded_dict = torch.load(pre_processed_file_path, 'rb')
+            loaded_dict = torch.load(pre_processed_file_path, 'rb', weights_only=False)
             self.graphs, self.labels = loaded_dict['graphs'], loaded_dict['labels']
 
         else:
@@ -133,7 +133,7 @@ class GraphPropPredDataset(object):
 
         # short-cut if split_dict.pt exists
         if os.path.isfile(os.path.join(path, 'split_dict.pt')):
-            return torch.load(os.path.join(path, 'split_dict.pt'))
+            return torch.load(os.path.join(path, 'split_dict.pt'), weights_only=False)
 
         train_idx = pd.read_csv(osp.join(path, 'train.csv.gz'), compression='gzip', header = None).values.T[0]
         valid_idx = pd.read_csv(osp.join(path, 'valid.csv.gz'), compression='gzip', header = None).values.T[0]

--- a/ogb/graphproppred/dataset_dgl.py
+++ b/ogb/graphproppred/dataset_dgl.py
@@ -79,7 +79,7 @@ class DglGraphPropPredDataset(object):
 
             if self.task_type == 'subtoken prediction':
                 self.graphs, _ = load_graphs(pre_processed_file_path)
-                self.labels = torch.load(target_sequence_file_path)
+                self.labels = torch.load(target_sequence_file_path, weights_only=False)
 
             else:
                 self.graphs, label_dict = load_graphs(pre_processed_file_path)
@@ -173,7 +173,7 @@ class DglGraphPropPredDataset(object):
 
         # short-cut if split_dict.pt exists
         if os.path.isfile(os.path.join(path, 'split_dict.pt')):
-            return torch.load(os.path.join(path, 'split_dict.pt'))
+            return torch.load(os.path.join(path, 'split_dict.pt'), weights_only=False)
 
         train_idx = pd.read_csv(osp.join(path, 'train.csv.gz'), compression='gzip', header = None).values.T[0]
         valid_idx = pd.read_csv(osp.join(path, 'valid.csv.gz'), compression='gzip', header = None).values.T[0]

--- a/ogb/graphproppred/dataset_pyg.py
+++ b/ogb/graphproppred/dataset_pyg.py
@@ -65,7 +65,7 @@ class PygGraphPropPredDataset(InMemoryDataset):
 
         super(PygGraphPropPredDataset, self).__init__(self.root, transform, pre_transform)
 
-        self.data, self.slices = torch.load(self.processed_paths[0])
+        self.data, self.slices = torch.load(self.processed_paths[0], weights_only=False)
 
     def get_idx_split(self, split_type = None):
         if split_type is None:
@@ -75,7 +75,7 @@ class PygGraphPropPredDataset(InMemoryDataset):
 
         # short-cut if split_dict.pt exists
         if os.path.isfile(os.path.join(path, 'split_dict.pt')):
-            return torch.load(os.path.join(path, 'split_dict.pt'))
+            return torch.load(os.path.join(path, 'split_dict.pt'), weights_only=False)
 
         train_idx = pd.read_csv(osp.join(path, 'train.csv.gz'), compression='gzip', header = None).values.T[0]
         valid_idx = pd.read_csv(osp.join(path, 'valid.csv.gz'), compression='gzip', header = None).values.T[0]

--- a/ogb/linkproppred/dataset.py
+++ b/ogb/linkproppred/dataset.py
@@ -64,7 +64,7 @@ class LinkPropPredDataset(object):
         pre_processed_file_path = osp.join(processed_dir, 'data_processed')
 
         if osp.exists(pre_processed_file_path):
-            self.graph = torch.load(pre_processed_file_path, 'rb')
+            self.graph = torch.load(pre_processed_file_path, 'rb', weights_only=False)
 
         else:
             ### check download
@@ -133,11 +133,11 @@ class LinkPropPredDataset(object):
 
         # short-cut if split_dict.pt exists
         if os.path.isfile(os.path.join(path, 'split_dict.pt')):
-            return torch.load(os.path.join(path, 'split_dict.pt'))
+            return torch.load(os.path.join(path, 'split_dict.pt'), weights_only=False)
 
-        train = torch.load(osp.join(path, 'train.pt'))
-        valid = torch.load(osp.join(path, 'valid.pt'))
-        test = torch.load(osp.join(path, 'test.pt'))
+        train = torch.load(osp.join(path, 'train.pt'), weights_only=False)
+        valid = torch.load(osp.join(path, 'valid.pt'), weights_only=False)
+        test = torch.load(osp.join(path, 'test.pt'), weights_only=False)
 
         return {'train': train, 'valid': valid, 'test': test}
 

--- a/ogb/linkproppred/dataset_pyg.py
+++ b/ogb/linkproppred/dataset_pyg.py
@@ -62,7 +62,7 @@ class PygLinkPropPredDataset(InMemoryDataset):
         self.binary = self.meta_info['binary'] == 'True'
 
         super(PygLinkPropPredDataset, self).__init__(self.root, transform, pre_transform)
-        self.data, self.slices = torch.load(self.processed_paths[0])
+        self.data, self.slices = torch.load(self.processed_paths[0], weights_only=False)
 
     def get_edge_split(self, split_type = None):
         if split_type is None:
@@ -72,11 +72,11 @@ class PygLinkPropPredDataset(InMemoryDataset):
 
         # short-cut if split_dict.pt exists
         if os.path.isfile(os.path.join(path, 'split_dict.pt')):
-            return torch.load(os.path.join(path, 'split_dict.pt'))
+            return torch.load(os.path.join(path, 'split_dict.pt'), weights_only=False)
 
-        train = replace_numpy_with_torchtensor(torch.load(osp.join(path, 'train.pt')))
-        valid = replace_numpy_with_torchtensor(torch.load(osp.join(path, 'valid.pt')))
-        test = replace_numpy_with_torchtensor(torch.load(osp.join(path, 'test.pt')))
+        train = replace_numpy_with_torchtensor(torch.load(osp.join(path, 'train.pt'), weights_only=False))
+        valid = replace_numpy_with_torchtensor(torch.load(osp.join(path, 'valid.pt'), weights_only=False))
+        test = replace_numpy_with_torchtensor(torch.load(osp.join(path, 'test.pt'), weights_only=False))
 
         return {'train': train, 'valid': valid, 'test': test}
 

--- a/ogb/lsc/mag240m.py
+++ b/ogb/lsc/mag240m.py
@@ -38,8 +38,8 @@ class MAG240MDataset(object):
                 shutil.rmtree(osp.join(self.dir))
 
         self.download()
-        self.__meta__ = torch.load(osp.join(self.dir, 'meta.pt'))
-        self.__split__ = torch.load(osp.join(self.dir, 'split_dict.pt'))
+        self.__meta__ = torch.load(osp.join(self.dir, 'meta.pt'), weights_only=False)
+        self.__split__ = torch.load(osp.join(self.dir, 'split_dict.pt'), weights_only=False)
 
         split_test(self.__split__)
 

--- a/ogb/lsc/pcqm4m.py
+++ b/ogb/lsc/pcqm4m.py
@@ -82,7 +82,7 @@ class PCQM4MDataset(object):
 
         if osp.exists(pre_processed_file_path):        
             # if pre-processed file already exists
-            loaded_dict = torch.load(pre_processed_file_path, 'rb')
+            loaded_dict = torch.load(pre_processed_file_path, 'rb', weights_only=False)
             self.graphs, self.labels = loaded_dict['graphs'], loaded_dict['labels']
         
         else:
@@ -124,7 +124,7 @@ class PCQM4MDataset(object):
             torch.save({'graphs': self.graphs, 'labels': self.labels}, pre_processed_file_path, pickle_protocol=4)
 
     def get_idx_split(self):
-        split_dict = torch.load(osp.join(self.folder, 'split_dict.pt'))
+        split_dict = torch.load(osp.join(self.folder, 'split_dict.pt'), weights_only=False)
         return split_dict
 
     def __getitem__(self, idx):

--- a/ogb/lsc/pcqm4m_dgl.py
+++ b/ogb/lsc/pcqm4m_dgl.py
@@ -109,7 +109,7 @@ class DglPCQM4MDataset(object):
 
 
     def get_idx_split(self):
-        split_dict = replace_numpy_with_torchtensor(torch.load(osp.join(self.folder, 'split_dict.pt')))
+        split_dict = replace_numpy_with_torchtensor(torch.load(osp.join(self.folder, 'split_dict.pt'), weights_only=False))
         return split_dict
 
     def __getitem__(self, idx):

--- a/ogb/lsc/pcqm4m_pyg.py
+++ b/ogb/lsc/pcqm4m_pyg.py
@@ -43,7 +43,7 @@ class PygPCQM4MDataset(InMemoryDataset):
 
         super(PygPCQM4MDataset, self).__init__(self.folder, transform, pre_transform)
 
-        self.data, self.slices = torch.load(self.processed_paths[0])
+        self.data, self.slices = torch.load(self.processed_paths[0], weights_only=False)
 
     @property
     def raw_file_names(self):
@@ -102,7 +102,7 @@ class PygPCQM4MDataset(InMemoryDataset):
         torch.save((data, slices), self.processed_paths[0])
 
     def get_idx_split(self):
-        split_dict = replace_numpy_with_torchtensor(torch.load(osp.join(self.root, 'split_dict.pt')))
+        split_dict = replace_numpy_with_torchtensor(torch.load(osp.join(self.root, 'split_dict.pt'), weights_only=False))
         return split_dict
 
 if __name__ == '__main__':

--- a/ogb/lsc/pcqm4mv2.py
+++ b/ogb/lsc/pcqm4mv2.py
@@ -79,7 +79,7 @@ class PCQM4Mv2Dataset(object):
 
         if osp.exists(pre_processed_file_path):        
             # if pre-processed file already exists
-            loaded_dict = torch.load(pre_processed_file_path, 'rb')
+            loaded_dict = torch.load(pre_processed_file_path, 'rb', weights_only=False)
             self.graphs, self.labels = loaded_dict['graphs'], loaded_dict['labels']
         
         else:
@@ -122,7 +122,7 @@ class PCQM4Mv2Dataset(object):
             torch.save({'graphs': self.graphs, 'labels': self.labels}, pre_processed_file_path, pickle_protocol=4)
 
     def get_idx_split(self):
-        split_dict = torch.load(osp.join(self.folder, 'split_dict.pt'))
+        split_dict = torch.load(osp.join(self.folder, 'split_dict.pt'), weights_only=False)
         return split_dict
 
     def __getitem__(self, idx):

--- a/ogb/lsc/pcqm4mv2_dgl.py
+++ b/ogb/lsc/pcqm4mv2_dgl.py
@@ -107,7 +107,7 @@ class DglPCQM4Mv2Dataset(object):
 
 
     def get_idx_split(self):
-        split_dict = replace_numpy_with_torchtensor(torch.load(osp.join(self.folder, 'split_dict.pt')))
+        split_dict = replace_numpy_with_torchtensor(torch.load(osp.join(self.folder, 'split_dict.pt'), weights_only=False))
         return split_dict
 
     def __getitem__(self, idx):

--- a/ogb/lsc/pcqm4mv2_pyg.py
+++ b/ogb/lsc/pcqm4mv2_pyg.py
@@ -40,7 +40,7 @@ class PygPCQM4Mv2Dataset(InMemoryDataset):
 
         super(PygPCQM4Mv2Dataset, self).__init__(self.folder, transform, pre_transform)
 
-        self.data, self.slices = torch.load(self.processed_paths[0])
+        self.data, self.slices = torch.load(self.processed_paths[0], weights_only=False)
 
     @property
     def raw_file_names(self):
@@ -100,7 +100,7 @@ class PygPCQM4Mv2Dataset(InMemoryDataset):
         torch.save((data, slices), self.processed_paths[0])
 
     def get_idx_split(self):
-        split_dict = replace_numpy_with_torchtensor(torch.load(osp.join(self.root, 'split_dict.pt')))
+        split_dict = replace_numpy_with_torchtensor(torch.load(osp.join(self.root, 'split_dict.pt'), weights_only=False))
         return split_dict
 
 if __name__ == '__main__':

--- a/ogb/lsc/wikikg90m.py
+++ b/ogb/lsc/wikikg90m.py
@@ -35,7 +35,7 @@ class WikiKG90MDataset(object):
                 shutil.rmtree(osp.join(self.folder))
 
         self.download()
-        self.__meta__ = torch.load(osp.join(self.folder, 'meta.pt'))
+        self.__meta__ = torch.load(osp.join(self.folder, 'meta.pt'), weights_only=False)
 
         # training triplet
         path = osp.join(self.processed_dir, 'train_hrt.npy')

--- a/ogb/lsc/wikikg90mv2.py
+++ b/ogb/lsc/wikikg90mv2.py
@@ -35,7 +35,7 @@ class WikiKG90Mv2Dataset(object):
                 shutil.rmtree(osp.join(self.folder))
 
         self.download()
-        self.__meta__ = torch.load(osp.join(self.folder, 'meta.pt'))
+        self.__meta__ = torch.load(osp.join(self.folder, 'meta.pt'), weights_only=False)
 
         # training triplet
         path = osp.join(self.processed_dir, 'train_hrt.npy')

--- a/ogb/nodeproppred/dataset.py
+++ b/ogb/nodeproppred/dataset.py
@@ -67,7 +67,7 @@ class NodePropPredDataset(object):
         pre_processed_file_path = osp.join(processed_dir, 'data_processed')
 
         if osp.exists(pre_processed_file_path):
-            loaded_dict = torch.load(pre_processed_file_path)
+            loaded_dict = torch.load(pre_processed_file_path, weights_only=False)
             self.graph, self.labels = loaded_dict['graph'], loaded_dict['labels']
 
         else:
@@ -147,7 +147,7 @@ class NodePropPredDataset(object):
 
         # short-cut if split_dict.pt exists
         if os.path.isfile(os.path.join(path, 'split_dict.pt')):
-            return torch.load(os.path.join(path, 'split_dict.pt'))
+            return torch.load(os.path.join(path, 'split_dict.pt'), weights_only=False)
             
         if self.is_hetero:
             train_idx_dict, valid_idx_dict, test_idx_dict = read_nodesplitidx_split_hetero(path)

--- a/ogb/nodeproppred/dataset_dgl.py
+++ b/ogb/nodeproppred/dataset_dgl.py
@@ -189,7 +189,7 @@ class DglNodePropPredDataset(object):
 
         # short-cut if split_dict.pt exists
         if os.path.isfile(os.path.join(path, 'split_dict.pt')):
-            return torch.load(os.path.join(path, 'split_dict.pt'))
+            return torch.load(os.path.join(path, 'split_dict.pt'), weights_only=False)
 
         if self.is_hetero:
             train_idx_dict, valid_idx_dict, test_idx_dict = read_nodesplitidx_split_hetero(path)


### PR DESCRIPTION
This is an error I get when loading data.

```
(1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
(2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.

WeightsUnpickler error: Unsupported global: GLOBAL numpy.core.multiarray._reconstruct was not an allowed global by default. Please use `torch.serialization.add_safe_globals([numpy.core.multiarray._reconstruct])` or the `torch.serialization.safe_globals([numpy.core.multiarray._reconstruct])` context manager to allowlist this global if you trust this class/function.
```

The error is simple and its because Pytorch mantainers decided it was a good idea to change their underlying API for torch.load. The default was ``weights_only` = False`, and now it is set to True. I went through and changed all `torch.load` instances and passed ``weights_only` = False`

I am aware of #508, #497 and #507, but all of them unfortunately only fix one or two instances. 

There are no automated tests, I could see to run locally. Would love some guidance on that.